### PR TITLE
feat: cascade dispatch to propagate default settings to downstream repos

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -1,0 +1,3 @@
+[
+  "robinmordasiewicz/f5xc-ddos-administration-guide"
+]

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -1,0 +1,31 @@
+name: Dispatch Downstream Enforcement
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/default-repo-settings.json'
+
+permissions:
+  contents: read
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Dispatch to downstream repos
+        env:
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+        run: |
+          repos=$(jq -r '.[]' .github/config/downstream-repos.json)
+          for repo in $repos; do
+            echo "Dispatching to $repo..."
+            if gh workflow run enforce-repo-settings.yml --repo "$repo"; then
+              echo "  [OK] $repo"
+            else
+              echo "  [FAIL] $repo"
+            fi
+          done

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -7,6 +7,7 @@ on:
     branches: [main]
     paths:
       - '.github/config/repo-settings.json'
+      - '.github/config/default-repo-settings.json'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary

- Add `downstream-repos.json` config listing repos that consume the reusable workflow
- Add `dispatch-downstream.yml` workflow that triggers on `default-repo-settings.json` changes and dispatches `workflow_dispatch` to each downstream repo
- Update `enforce-repo-settings.yml` paths trigger to also fire when defaults change

Closes #1

## Test plan

- [ ] Push a trivial change to `default-repo-settings.json` after merge
- [ ] Verify `dispatch-downstream.yml` fires in Actions tab
- [ ] Verify `enforce-repo-settings.yml` fires in `f5xc-ddos-administration-guide` via workflow_dispatch
- [ ] Check logs show defaults fetched and all phases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)