### PR TITLE
fix: remove temporary test key from default-repo-settings.json

### DIFF
--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -48,6 +48,5 @@
   "topics": [],
   "pages": {
     "enabled": true
-  },
-  "_test_cascade": true
+  }
 }


### PR DESCRIPTION
## Summary

- Remove the `_test_cascade` key added in #3 to verify cascade dispatch — test passed, cleanup complete

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)