### PR TITLE
feat: add pages.build_type to default-repo-settings.json

### DIFF
--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -47,6 +47,7 @@
   ],
   "topics": [],
   "pages": {
-    "enabled": true
+    "enabled": true,
+    "build_type": "workflow"
   }
 }


### PR DESCRIPTION
## Summary

- Add `"build_type": "workflow"` to the `pages` config in defaults
- This triggers cascade dispatch to all downstream repos on merge
- Downstream repos will now have Pages build_type enforced as workflow source

Closes #7

## Test plan

- [ ] Merge this PR
- [ ] Verify `dispatch-downstream.yml` fires
- [ ] Verify `enforce-repo-settings.yml` fires in downstream repos
- [ ] Check Phase 6 logs show `build_type` enforcement
- [ ] Check Phase 7 logs show `pages.build_type` verification passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)