### PR TITLE
feat: create canonical directory for managed file enforcement

### DIFF
--- a/.github/canonical/.editorconfig
+++ b/.github/canonical/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false
+
+[Makefile]
+indent_style = tab

--- a/.github/canonical/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/canonical/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+description: Report a bug or unexpected behavior
+labels: ["bug"]
+---
+
+## Describe the Bug
+
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Expected Behavior
+
+A clear and concise description of what you expected to happen.
+
+## Actual Behavior
+
+A clear and concise description of what actually happened.
+
+## Environment
+
+- OS: [e.g., macOS 14.0, Ubuntu 22.04]
+- Browser: [e.g., Chrome 120, Firefox 121]
+- Version/Commit: [e.g., commit SHA or tag]
+
+## Additional Context
+
+Add any other context, screenshots, or log output about the problem here.

--- a/.github/canonical/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/canonical/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/canonical/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/canonical/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,21 @@
+---
+name: Documentation
+description: Suggest a documentation improvement or report missing docs
+labels: ["documentation"]
+---
+
+## What Needs to Be Documented
+
+Describe the topic, feature, or area that needs documentation.
+
+## Current State
+
+Describe the current state of the documentation (missing, incomplete, outdated, unclear).
+
+## Suggested Improvement
+
+Describe what the documentation should cover or how it should be improved.
+
+## Additional Context
+
+Add any references, examples, or links that would help with the documentation.

--- a/.github/canonical/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/canonical/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+---
+
+## Feature Description
+
+A clear and concise description of the feature you'd like.
+
+## Use Case / Motivation
+
+Explain the problem this feature would solve or the value it would provide.
+
+## Proposed Solution
+
+Describe how you'd like this feature to work.
+
+## Alternatives Considered
+
+Describe any alternative solutions or features you've considered.
+
+## Additional Context
+
+Add any other context, mockups, or references about the feature request here.

--- a/.github/canonical/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/canonical/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+## Summary
+
+Brief description of the changes in this PR.
+
+## Related Issue
+
+Closes #
+
+## Changes
+
+-
+
+## Checklist
+
+- [ ] Linked to a GitHub issue (required — CI will block merge without it)
+- [ ] Tested locally
+- [ ] Follows project conventions

--- a/.github/canonical/.github/workflows/deploy.yml
+++ b/.github/canonical/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy Docs
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  docs:
+    uses: robinmordasiewicz/f5xc-docs-builder/.github/workflows/docs-build-deploy.yml@main

--- a/.github/canonical/.github/workflows/enforce-repo-settings.yml
+++ b/.github/canonical/.github/workflows/enforce-repo-settings.yml
@@ -1,0 +1,19 @@
+name: Enforce Repository Settings
+
+on:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: [main]
+    paths:
+      - '.github/config/repo-settings.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  enforce:
+    uses: robinmordasiewicz/f5xc-docs-builder/.github/workflows/enforce-repo-settings.yml@main
+    secrets:
+      repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/canonical/.github/workflows/require-linked-issue.yml
+++ b/.github/canonical/.github/workflows/require-linked-issue.yml
@@ -1,0 +1,21 @@
+name: Require Linked Issue
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  issues: read
+  pull-requests: write
+
+jobs:
+  check-linked-issue:
+    runs-on: ubuntu-latest
+    name: Check linked issues
+    steps:
+      - uses: nearform-actions/github-action-check-linked-issues@v1
+        with:
+          exclude-branches: "dependabot/**"
+          custom-message: "This PR must be linked to a GitHub issue. Use 'Closes #123' in the PR description, or link an issue from the sidebar."
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/canonical/.gitignore
+++ b/.github/canonical/.gitignore
@@ -1,0 +1,6 @@
+.DS_Store
+node_modules/
+dist/
+.env
+.env.*
+*.log

--- a/.github/canonical/CLAUDE.md
+++ b/.github/canonical/CLAUDE.md
@@ -1,0 +1,35 @@
+# Claude Code Project Instructions
+
+## Repository Workflow
+
+This repo enforces a strict governance workflow. Follow it exactly:
+
+1. **Create a GitHub issue** before making any changes
+2. **Create a feature branch** from `main` — never commit to `main` directly
+3. **Open a PR** that links to the issue using `Closes #N`
+4. **CI must pass** — the "Check linked issues" check blocks PRs without a linked issue
+5. **Merge** — squash merge preferred, branch auto-deletes after merge
+
+## Use the `/ship` Skill
+
+When available, use `/ship` to handle the full workflow (issue creation, branch, commit, PR) in one step.
+
+## Branch Naming
+
+Use the format `<prefix>/<issue-number>-short-description`:
+
+- `feature/42-add-rate-limiting`
+- `fix/17-correct-threshold`
+- `docs/8-update-guide`
+
+## Rules
+
+- Never push directly to `main`
+- Never force push
+- Every PR must link to an issue
+- Fill out the PR template completely
+- Follow conventional commit messages (`feat:`, `fix:`, `docs:`)
+
+## Reference
+
+Read `CONTRIBUTING.md` for full governance details.

--- a/.github/canonical/CONTRIBUTING.md
+++ b/.github/canonical/CONTRIBUTING.md
@@ -1,0 +1,84 @@
+# Contributing
+
+Thank you for your interest in contributing. This document describes the workflow and rules that all contributors — human and AI — must follow.
+
+## Workflow Overview
+
+Every change follows this path:
+
+```
+Issue → Branch → PR (linked to issue) → CI passes → Merge → Branch auto-deleted
+```
+
+No exceptions. PRs without a linked issue will be blocked by CI.
+
+## Step 1: Create an Issue
+
+Every change starts with a GitHub issue. Use one of the provided templates:
+
+- **Bug Report** — for bugs and unexpected behavior
+- **Feature Request** — for new features and improvements
+- **Documentation** — for docs improvements or missing content
+
+Blank issues are disabled. Pick the template that best fits your change.
+
+## Step 2: Create a Feature Branch
+
+Branch from `main` using one of these naming conventions:
+
+| Prefix | Use for | Example |
+|--------|---------|---------|
+| `feature/` | New features | `feature/42-add-rate-limiting` |
+| `fix/` | Bug fixes | `fix/17-correct-threshold-calc` |
+| `docs/` | Documentation | `docs/8-update-setup-guide` |
+
+Format: `<prefix>/<issue-number>-short-description`
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b feature/42-add-rate-limiting
+```
+
+## Step 3: Make Changes and Commit
+
+- Write small, focused commits
+- Use conventional commit messages:
+  - `feat: add rate limiting configuration`
+  - `fix: correct threshold calculation`
+  - `docs: update setup guide`
+
+## Step 4: Open a Pull Request
+
+1. Push your branch and open a PR against `main`
+2. **Link the issue** — use `Closes #42` in the PR description, or link from the sidebar
+3. Fill out the PR template (it loads automatically)
+4. The **"Check linked issues"** CI check will block merge if no issue is linked
+
+## Step 5: Review and Merge
+
+- All CI checks must pass before merge
+- Squash merge is preferred
+- The branch is automatically deleted after merge (`delete_branch_on_merge` is enabled)
+
+## Branch Protection Rules
+
+The `main` branch is protected. The following rules are enforced:
+
+- No direct pushes to `main` — all changes go through PRs
+- No force pushes
+- Required status check: **"Check linked issues"** must pass
+- Admin enforcement enabled — these rules apply to everyone
+
+## AI Assistant Guidelines
+
+If you are Claude Code, Copilot, or another AI coding assistant, follow these rules:
+
+1. **Always create a GitHub issue before writing code.** No issue = no work.
+2. **Always work on a feature branch.** Never commit directly to `main`.
+3. **Always link the PR to the issue.** Use `Closes #N` in the PR description.
+4. **Use the `/ship` skill** when available — it handles the full Issue → Branch → PR flow.
+5. **Never force push** or attempt to bypass branch protection.
+6. **Fill out the PR template checklist** completely.
+7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
+8. **Respect CODEOWNERS** — `@robinmordasiewicz` is the default reviewer.

--- a/.github/canonical/LICENSE
+++ b/.github/canonical/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Robin Mordasiewicz
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Create `.github/canonical/` directory with 13 source-of-truth files for downstream repo sync
- Includes workflow callers, GitHub templates, governance docs, and project config files
- Each file path maps 1:1 to its downstream repo location

Closes #9

## Changes

- New `.github/canonical/` directory containing:
  - `.github/workflows/deploy.yml` (downstream variant — no `default-repo-settings.json` trigger)
  - `.github/workflows/enforce-repo-settings.yml` (downstream variant — `repo-settings.json` trigger only)
  - `.github/workflows/require-linked-issue.yml`
  - `.github/PULL_REQUEST_TEMPLATE.md`
  - `.github/ISSUE_TEMPLATE/bug_report.md`
  - `.github/ISSUE_TEMPLATE/feature_request.md`
  - `.github/ISSUE_TEMPLATE/documentation.md`
  - `.github/ISSUE_TEMPLATE/config.yml`
  - `CONTRIBUTING.md`
  - `CLAUDE.md`
  - `.editorconfig`
  - `.gitignore`
  - `LICENSE` (MIT)

## Test plan

- [x] Verify all 13 files exist under `.github/canonical/`
- [x] Verify downstream workflow callers don't trigger on `default-repo-settings.json`
- [ ] Nothing reads this directory yet — safe to merge independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)