### PR TITLE
feat: copy astro.config.mjs from theme at build time

### DIFF
--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -29,6 +29,9 @@ jobs:
           repository: robinmordasiewicz/f5xc-docs-theme
           path: builder/theme
 
+      - name: Copy Astro config from theme
+        run: cp builder/theme/astro.config.mjs builder/astro.config.mjs
+
       - name: Setup Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Add a build step to copy `astro.config.mjs` from the theme checkout (`builder/theme/`) into the builder root
- This enables marketing to control Astro/Starlight configuration via the theme repo (robinmordasiewicz/f5xc-docs-theme#2)

Closes #13

## Test plan
- [ ] Merge robinmordasiewicz/f5xc-docs-theme#2 first (adds the config file to the theme)
- [ ] After this PR merges, trigger a downstream docs build (e.g., f5xc-ddos-administration-guide)
- [ ] Verify the build succeeds with the config sourced from the theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)