### PR TITLE
fix: rename deploy.yml to github-pages-deploy.yml

### DIFF
--- a/.github/canonical/.github/workflows/github-pages-deploy.yml
+++ b/.github/canonical/.github/workflows/github-pages-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy Docs
+name: GitHub Pages Deploy
 on:
   push:
     branches: [main]

--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -54,7 +54,7 @@
     "source_repo": "robinmordasiewicz/f5xc-template",
     "source_base": ".github/canonical",
     "files": [
-      ".github/workflows/deploy.yml",
+      ".github/workflows/github-pages-deploy.yml",
       ".github/workflows/enforce-repo-settings.yml",
       ".github/workflows/require-linked-issue.yml",
       ".github/PULL_REQUEST_TEMPLATE.md",


### PR DESCRIPTION
## Summary

- Rename canonical workflow from `deploy.yml` to `github-pages-deploy.yml` and update `name:` field to `GitHub Pages Deploy`
- Update `managed_files` in `default-repo-settings.json` to reference the new filename

## Test plan

- [ ] Verify `github-pages-deploy.yml` exists in canonical and `deploy.yml` is gone
- [ ] After merge, confirm Phase 7 sees the new filename in managed_files
- [ ] Ship downstream rename in f5xc-ddos-administration-guide after this merges

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)