### PR TITLE
fix: detect status check drift when checks need to be added

### DIFF
--- a/.github/workflows/enforce-repo-settings-reusable.yml
+++ b/.github/workflows/enforce-repo-settings-reusable.yml
@@ -158,10 +158,17 @@ jobs:
               fi
 
               desired_checks=$(echo "$DESIRED_PAYLOAD" | jq -c '.required_status_checks')
+              current_checks=$(echo "$CURRENT_PROTECTION" | jq -c '.required_status_checks')
               if [ "$desired_checks" = "null" ]; then
-                current_checks=$(echo "$CURRENT_PROTECTION" | jq -c '.required_status_checks')
                 if [ "$current_checks" != "null" ]; then
-                  echo "[WARN] Drift in required_status_checks"
+                  echo "[WARN] Drift in required_status_checks: should be disabled"
+                  PROTECTION_DRIFT=true
+                fi
+              else
+                desired_contexts=$(echo "$desired_checks" | jq -c '[.contexts[]?] // []' 2>/dev/null || echo '[]')
+                current_contexts=$(echo "$current_checks" | jq -c '[.contexts[]?] // []' 2>/dev/null || echo '[]')
+                if [ "$desired_contexts" != "$current_contexts" ]; then
+                  echo "[WARN] Drift in required_status_checks.contexts: current=$current_contexts desired=$desired_contexts"
                   PROTECTION_DRIFT=true
                 fi
               fi


### PR DESCRIPTION
## Summary

- Fix Phase 4 drift detection for `required_status_checks` — previously only detected when checks needed to be removed (desired=null), now also detects when checks need to be added or updated (desired=non-null, current differs)

## Test plan

- [ ] Remove status checks from a downstream repo, run governance, verify checks are restored
- [ ] Verify governance still correctly handles the null case (no desired checks)

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)