### PR TITLE
refactor: remove theme git clone steps from docs-build-deploy workflow

### DIFF
--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -23,15 +23,6 @@ jobs:
           repository: robinmordasiewicz/f5xc-docs-builder
           path: builder
 
-      - name: Checkout theme
-        uses: actions/checkout@v5
-        with:
-          repository: robinmordasiewicz/f5xc-docs-theme
-          path: builder/theme
-
-      - name: Copy Astro config from theme
-        run: cp builder/theme/astro.config.mjs builder/astro.config.mjs
-
       - name: Setup Node
         uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
Closes #28

## Summary
Remove the theme repository checkout and astro config copy steps since the theme is now installed via npm as a dependency of the builder.

## Changes
- Removes: Checkout theme step that cloned robinmordasiewicz/f5xc-docs-theme repository
- Removes: Copy Astro config from theme step
- Simplifies the workflow by relying on npm dependencies

## Benefits
- Reduces build time by eliminating an additional git clone operation
- Simplifies the workflow configuration
- Theme version is now managed through package.json dependencies

## Testing
- Workflow will be validated by GitHub Actions CI checks