### PR TITLE
feat: add f5xc-docs-builder and f5xc-docs-theme to downstream repos config

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -1,3 +1,5 @@
 [
-  "robinmordasiewicz/f5xc-ddos-administration-guide"
+  "robinmordasiewicz/f5xc-ddos-administration-guide",
+  "robinmordasiewicz/f5xc-docs-builder",
+  "robinmordasiewicz/f5xc-docs-theme"
 ]

--- a/.github/workflows/docs-build-deploy.yml
+++ b/.github/workflows/docs-build-deploy.yml
@@ -7,60 +7,80 @@ on:
         required: false
         default: 'docs'
         type: string
+      builder-image:
+        description: 'Builder Docker image URI'
+        required: false
+        default: 'ghcr.io/robinmordasiewicz/f5xc-docs-builder:latest'
+        type: string
+      docs-title:
+        description: 'Documentation site title (overrides frontmatter)'
+        required: false
+        type: string
+      docs-site:
+        description: 'Documentation site URL'
+        required: false
+        default: 'https://robinmordasiewicz.github.io'
+        type: string
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    outputs:
+      build-status: ${{ job.status }}
     steps:
       - name: Checkout content repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v4
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
         with:
-          path: content
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Node
-        uses: actions/setup-node@v6
-        with:
-          node-version: 22
-          cache: npm
-          cache-dependency-path: content/package-lock.json
-
-      - name: Install dependencies
-        working-directory: content
-        run: npm ci
-
-      - name: Copy Astro config from theme
-        run: cp content/node_modules/f5xc-docs-theme/astro.config.mjs content/astro.config.mjs
-
-      - name: Inject content
+      - name: Build docs with container
         run: |
-          rm -rf content/src/content/docs/*
-          cp -r content/${{ inputs.content-path }}/* content/src/content/docs/
+          mkdir -p ${{ runner.temp }}/docs-output
 
-      - name: Extract metadata
-        id: meta
+          docker run --rm \
+            --name docs-builder \
+            -v ${{ github.workspace }}/${{ inputs.content-path }}:/content/docs:ro \
+            -v ${{ runner.temp }}/docs-output:/output \
+            -e CONTENT_DIR=/content/docs \
+            -e OUTPUT_DIR=/output \
+            -e DOCS_SITE="${{ inputs.docs-site }}" \
+            -e GITHUB_REPOSITORY="${{ github.repository }}" \
+            ${{ inputs.docs-title && format('-e DOCS_TITLE="{0}"', inputs.docs-title) || '' }} \
+            ${{ inputs.builder-image }}
+
+          echo "✅ Build completed successfully"
+          ls -lah ${{ runner.temp }}/docs-output/
+
+      - name: Verify build output
         run: |
-          REPO_NAME="${GITHUB_REPOSITORY#*/}"
-          TITLE=$(grep -m1 '^title:' content/src/content/docs/index.mdx | sed 's/title: *["]*//;s/["]*$//' || echo "$REPO_NAME")
-          echo "title=$TITLE" >> "$GITHUB_OUTPUT"
-          echo "base=/$REPO_NAME" >> "$GITHUB_OUTPUT"
+          OUTPUT_DIR="${{ runner.temp }}/docs-output"
 
-      - name: Build
-        working-directory: content
-        env:
-          DOCS_TITLE: ${{ steps.meta.outputs.title }}
-          DOCS_BASE: ${{ steps.meta.outputs.base }}
-          DOCS_SITE: https://robinmordasiewicz.github.io
-          GITHUB_REPOSITORY: ${{ github.repository }}
-        run: npm run build
+          if [ ! -d "$OUTPUT_DIR" ] || [ -z "$(ls -A $OUTPUT_DIR)" ]; then
+            echo "❌ Build output is empty"
+            exit 1
+          fi
+
+          echo "✅ Build output verified"
+          echo "Files generated:"
+          find "$OUTPUT_DIR" -type f | head -20
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: content/dist
+          path: ${{ runner.temp }}/docs-output
+          retention-days: 1
 
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    if: success()
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
## Summary

Extend downstream repos configuration and refactor docs build workflow to use containerized builder.

## Changes

- **downstream-repos.json**: Add f5xc-docs-builder and f5xc-docs-theme to enable automated updates
- **docs-build-deploy.yml**: 
  - Refactor to use Docker container for builds instead of Node.js toolchain
  - Add builder-image input parameter for flexible builder version management
  - Add docs-title input to override frontmatter title
  - Add docs-site input parameter for documentation site URL
  - Improve build verification and artifact handling
  - Switch to GitHub Container Registry authentication

## Benefits

✅ Enables automated updates of downstream documentation repos
✅ Decouples build toolchain from workflow runners
✅ Improves build consistency through containerization
✅ Provides flexible configuration options for documentation builds
✅ Better build verification and error handling

Closes #34