### PR TITLE
feat: add downstream-repos.json to dispatch trigger paths

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
     paths:
       - '.github/config/default-repo-settings.json'
+      - '.github/config/downstream-repos.json'
       - 'workflows/**'
       - '.github/workflows/enforce-repo-settings.yml'
       - '.github/workflows/docs-build-deploy.yml'


### PR DESCRIPTION
Add downstream-repos.json to dispatch workflow trigger paths

## Description
Changes to the downstream repositories configuration list now automatically trigger enforcement dispatch to all downstream repos.

## Changes
- Modified 
- Added  to push event paths

## Impact
- Repository governance updates now automatically propagate downstream
- Ensures consistent policy enforcement across all downstream repositories

Closes #36