### PR TITLE
fix: add .astro/ and astro.config.mjs to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ dist/
 .env
 .env.*
 *.log
+.astro/
+astro.config.mjs


### PR DESCRIPTION
## Summary
- Add `.astro/` (build cache) and `astro.config.mjs` (generated from theme) to the managed `.gitignore`
- These entries will propagate to all downstream repos via the sync workflow

## Test plan
- [ ] CI passes
- [ ] After merge, downstream sync picks up the updated `.gitignore`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)