### PR TITLE
fix: remove astro.config.mjs from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ dist/
 .env.*
 *.log
 .astro/
-astro.config.mjs


### PR DESCRIPTION
## Summary
- Remove `astro.config.mjs` from `.gitignore` — it should not be ignored

## Test plan
- [ ] CI passes

Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)