### PR TITLE
fix: add packages:read permission to pages deploy workflow

### DIFF
--- a/workflows/github-pages-deploy.yml
+++ b/workflows/github-pages-deploy.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
   pages: write
   id-token: write
 


### PR DESCRIPTION
## Summary
- Add `packages: read` to the pages deploy caller workflow permissions
- Required for the reusable workflow to pull the builder Docker image from GHCR

## Test plan
- [ ] CI passes
- [ ] Downstream pages deploy no longer gets startup_failure

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)