### PR TITLE
feat: expand enforce workflow trigger to all .github/config/ changes

### DIFF
--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -6,7 +6,7 @@ on:
   push:
     branches: [main]
     paths:
-      - '.github/config/repo-settings.json'
+      - '.github/config/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Closes #48

## Summary
Expand the enforce-repo-settings workflow trigger to run on any changes within the .github/config/ directory.

## Changes
- Updated workflow path trigger from '.github/config/repo-settings.json' to '.github/config/**'

## Impact
- Workflow will now execute on any configuration file changes in .github/config/
- Ensures repo settings enforcement applies to all config modifications