### PR TITLE
feat: add workflow_dispatch trigger to github-pages-deploy.yml

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -1,5 +1,6 @@
 name: Build and Deploy Docs
 on:
+  workflow_dispatch:
   workflow_call:
     inputs:
       content-path:
@@ -46,14 +47,14 @@ jobs:
 
           docker run --rm \
             --name docs-builder \
-            -v ${{ github.workspace }}/${{ inputs.content-path }}:/content/docs:ro \
+            -v ${{ github.workspace }}/${{ inputs.content-path || 'docs' }}:/content/docs:ro \
             -v ${{ runner.temp }}/docs-output:/output \
             -e CONTENT_DIR=/content/docs \
             -e OUTPUT_DIR=/output \
-            -e DOCS_SITE="${{ inputs.docs-site }}" \
+            -e DOCS_SITE="${{ inputs.docs-site || 'https://robinmordasiewicz.github.io' }}" \
             -e GITHUB_REPOSITORY="${{ github.repository }}" \
             ${{ inputs.docs-title && format('-e DOCS_TITLE="{0}"', inputs.docs-title) || '' }} \
-            ${{ inputs.builder-image }}
+            ${{ inputs.builder-image || 'ghcr.io/robinmordasiewicz/f5xc-docs-builder:latest' }}
 
           echo "✅ Build completed successfully"
           ls -lah ${{ runner.temp }}/docs-output/


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to `github-pages-deploy.yml` so it can be dispatched by the `f5xc-docs-builder` post-build job
- Add `||` fallback defaults for `inputs.content-path`, `inputs.docs-site`, and `inputs.builder-image` so the workflow works correctly when dispatched directly (without `workflow_call` inputs)

## Problem
The `build-image.yml` dispatch job in `f5xc-docs-builder` runs `gh workflow run github-pages-deploy.yml --repo f5xc-template`, which fails with HTTP 422 because the workflow only had a `workflow_call` trigger.

Reference: https://github.com/robinmordasiewicz/f5xc-docs-builder/actions/runs/21794064914

## Test plan
- [ ] Verify the workflow can be manually dispatched via `gh workflow run github-pages-deploy.yml --repo robinmordasiewicz/f5xc-template`
- [ ] Verify downstream repos can still call the workflow via `workflow_call`
- [ ] Verify the `f5xc-docs-builder` dispatch job succeeds end-to-end

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)