### PR TITLE
Add reusable auto-merge workflow

### DIFF
--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -61,6 +61,7 @@
       {"src": ".github/ISSUE_TEMPLATE/feature_request.md", "dest": ".github/ISSUE_TEMPLATE/feature_request.md"},
       {"src": ".github/ISSUE_TEMPLATE/documentation.md", "dest": ".github/ISSUE_TEMPLATE/documentation.md"},
       {"src": ".github/ISSUE_TEMPLATE/config.yml", "dest": ".github/ISSUE_TEMPLATE/config.yml"},
+      {"src": "workflows/auto-merge.yml", "dest": ".github/workflows/auto-merge.yml"},
       {"src": "CONTRIBUTING.md", "dest": "CONTRIBUTING.md"},
       {"src": "CLAUDE.md", "dest": "CLAUDE.md"},
       {"src": ".editorconfig", "dest": ".editorconfig"},

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,0 +1,17 @@
+name: Auto Merge
+
+on:
+  workflow_call:
+
+jobs:
+  auto-merge:
+    name: Enable auto-merge
+    runs-on: ubuntu-latest
+    if: "!github.event.pull_request.draft"
+    steps:
+      - name: Enable auto-merge (squash)
+        continue-on-error: true
+        run: gh pr merge "$PR_URL" --auto --squash
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -1,0 +1,13 @@
+name: Auto Merge
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    uses: robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main


### PR DESCRIPTION
## Summary
- Add reusable workflow (`.github/workflows/auto-merge.yml`) that enables auto-merge (squash) on non-draft PRs
- Add caller template (`workflows/auto-merge.yml`) for downstream repos
- Register caller in `default-repo-settings.json` managed files for automatic sync

Closes #54

## Test plan
- [ ] Verify reusable workflow is available at `robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main` after merge
- [ ] Verify downstream repos receive the caller via `enforce-repo-settings`
- [ ] Verify future PRs show "auto-merge enabled (squash)" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)