### PR TITLE
fix: add workflow_dispatch trigger to reusable workflow

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -21,6 +21,27 @@ on:
         required: false
         default: 'https://robinmordasiewicz.github.io'
         type: string
+  workflow_dispatch:
+    inputs:
+      content-path:
+        description: 'Path to content directory'
+        required: false
+        default: 'docs'
+        type: string
+      builder-image:
+        description: 'Builder Docker image URI'
+        required: false
+        default: 'ghcr.io/robinmordasiewicz/f5xc-docs-builder:latest'
+        type: string
+      docs-title:
+        description: 'Documentation site title'
+        required: false
+        type: string
+      docs-site:
+        description: 'Documentation site URL'
+        required: false
+        default: 'https://robinmordasiewicz.github.io'
+        type: string
 
 jobs:
   build:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger alongside existing `workflow_call` in `github-pages-deploy.yml`
- Mirrors all `workflow_call` input defaults so the workflow builds f5xc-template's own docs when dispatched directly
- Fixes HTTP 422 error when f5xc-docs-builder dispatches to this repo

## Root Cause
The dispatch job in f5xc-docs-builder calls `gh workflow run github-pages-deploy.yml --repo f5xc-template`, but this workflow only had `workflow_call` (no `workflow_dispatch`), causing the 422 error.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, verify `gh workflow run github-pages-deploy.yml --repo robinmordasiewicz/f5xc-template` succeeds
- [ ] Existing `workflow_call` callers still work

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)