### PR TITLE
feat: add f5xc-docs to downstream repos

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -8,5 +8,6 @@
   "robinmordasiewicz/f5xc-auth",
   "robinmordasiewicz/f5xc-marketplace",
   "robinmordasiewicz/f5xc-api-mcp",
-  "robinmordasiewicz/f5xc-xcsh"
+  "robinmordasiewicz/f5xc-xcsh",
+  "robinmordasiewicz/f5xc-docs"
 ]


### PR DESCRIPTION
## Summary

Register the new `f5xc-docs` central documentation hub in the downstream repos config so it receives governance enforcement from the template.

## Related Issue

Closes #70

## Changes

- Added `robinmordasiewicz/f5xc-docs` to `.github/config/downstream-repos.json`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions