### PR TITLE
fix: use REPO_ADMIN_TOKEN in auto-merge for push event triggers

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -2,6 +2,9 @@ name: Auto Merge
 
 on:
   workflow_call:
+    secrets:
+      REPO_ADMIN_TOKEN:
+        required: false
 
 jobs:
   auto-merge:
@@ -14,4 +17,4 @@ jobs:
         run: gh pr merge "$PR_URL" --auto --squash
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN || secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -7,6 +7,7 @@ on:
       - '.github/config/default-repo-settings.json'
       - '.github/config/downstream-repos.json'
       - 'workflows/**'
+      - '.github/workflows/auto-merge.yml'
       - '.github/workflows/enforce-repo-settings.yml'
       - '.github/workflows/github-pages-deploy.yml'
       - '.github/workflows/require-linked-issue.yml'

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -11,3 +11,5 @@ permissions:
 jobs:
   auto-merge:
     uses: robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main
+    secrets:
+      REPO_ADMIN_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}


### PR DESCRIPTION
## Summary
- Auto-merge reusable workflow now accepts optional `REPO_ADMIN_TOKEN` secret
- When provided, uses it instead of `GITHUB_TOKEN` for `gh pr merge`
- Caller template (`workflows/auto-merge.yml`) passes `REPO_ADMIN_TOKEN` to reusable workflow
- Added `auto-merge.yml` to dispatch-downstream paths for managed file sync

This fixes the issue where merges by `app/github-actions` (using `GITHUB_TOKEN`) suppress push events, preventing `on: push` workflows from triggering.

Closes #72

## Test plan
- [ ] Merge this PR to template
- [ ] Wait for downstream sync to push updated caller workflow
- [ ] Create a test PR on f5xc-docs-builder and verify auto-merge uses REPO_ADMIN_TOKEN
- [ ] Verify push event triggers on:push workflows after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)