### PR TITLE
docs: improve contributing clarity and repo naming

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,7 @@ indent_style = space
 indent_size = 2
 
 [*.md]
-trim_trailing_whitespace = false
+trim_trailing_whitespace = true
 
 [Makefile]
 indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-Thank you for your interest in contributing. This document describes the workflow and rules that all contributors — human and AI — must follow.
+This document describes the workflow and rules that all contributors — human and AI — must follow.
 
 ## Workflow Overview
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Documentation Template
+# Repository Template
 
 Click **"Use this template"** to create a new documentation site.
 
@@ -18,5 +18,3 @@ docs/
   01-getting-started.mdx
   02-your-next-page.mdx
 ```
-
-All framework code, theme, and build tooling is managed centrally by the [f5xc-docs-builder](https://github.com/robinmordasiewicz/f5xc-docs-builder) repo. You only maintain content.


### PR DESCRIPTION
Closes #74

## Changes
- Update .editorconfig to enforce whitespace trimming on markdown files
- Simplify CONTRIBUTING.md opening line for better clarity
- Update README.md title to 'Repository Template' for accuracy
- Remove redundant framework management description

## Impact
- Better documentation clarity for contributors
- Consistent whitespace handling across markdown files
- More accurate repository naming and purpose statement