### PR TITLE
chore: add build artifacts and tool directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ dist/
 .env.*
 *.log
 .astro/
+site/
+projects/
+.venv/
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Add `site/`, `projects/`, `.venv/`, and `.playwright-mcp/` to `.gitignore`
- Prevents build output and local tool directories from being tracked
- Will propagate to all downstream repos via governance sync

Closes #76

## Test plan
- [ ] Verify `.gitignore` entries are correct
- [ ] Confirm `dispatch-downstream` workflow triggers after merge
- [ ] Check downstream repos receive sync PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)