### PR TITLE
feat: add docs-sites.json registry and dispatch trigger

### DIFF
--- a/.github/config/docs-sites.json
+++ b/.github/config/docs-sites.json
@@ -1,0 +1,47 @@
+[
+  {
+    "label": "F5 XC Authentication Guide",
+    "url": "https://robinmordasiewicz.github.io/f5xc-auth/llms-full.txt",
+    "description": "Shared authentication library for F5 Distributed Cloud MCP servers"
+  },
+  {
+    "label": "F5 XC DDoS Administration Guide",
+    "url": "https://robinmordasiewicz.github.io/f5xc-ddos-administration-guide/llms-full.txt",
+    "description": "Administration guide for configuring and managing DDoS protection"
+  },
+  {
+    "label": "F5 Distributed Cloud Plugin Marketplace",
+    "url": "https://robinmordasiewicz.github.io/f5xc-marketplace/llms-full.txt",
+    "description": "Automate F5 XC operations with Claude Code plugins"
+  },
+  {
+    "label": "xcsh CLI",
+    "url": "https://robinmordasiewicz.github.io/f5xc-xcsh/llms-full.txt",
+    "description": "Command-line interface for managing F5 Distributed Cloud"
+  },
+  {
+    "label": "F5 XC API Fixed Specs",
+    "url": "https://robinmordasiewicz.github.io/f5xc-api-fixed/llms-full.txt",
+    "description": "Validated and reconciled F5 Distributed Cloud OpenAPI specifications"
+  },
+  {
+    "label": "F5 Cloud Status MCP Server",
+    "url": "https://robinmordasiewicz.github.io/f5xc-cloudstatus-mcp/llms-full.txt",
+    "description": "MCP server for monitoring F5 Distributed Cloud service status"
+  },
+  {
+    "label": "F5XC API MCP Server",
+    "url": "https://robinmordasiewicz.github.io/f5xc-api-mcp/llms-full.txt",
+    "description": "MCP server exposing F5 Distributed Cloud APIs to AI assistants"
+  },
+  {
+    "label": "f5xc Docs Builder",
+    "url": "https://robinmordasiewicz.github.io/f5xc-docs-builder/llms-full.txt",
+    "description": "Containerized Astro + Starlight documentation build system"
+  },
+  {
+    "label": "XC Docs Theme",
+    "url": "https://robinmordasiewicz.github.io/f5xc-docs-theme/llms-full.txt",
+    "description": "Shared branding and styling for F5 Distributed Cloud documentation sites"
+  }
+]

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -6,6 +6,7 @@ on:
     paths:
       - '.github/config/default-repo-settings.json'
       - '.github/config/downstream-repos.json'
+      - '.github/config/docs-sites.json'
       - 'workflows/**'
       - '.github/workflows/auto-merge.yml'
       - '.github/workflows/enforce-repo-settings.yml'


### PR DESCRIPTION
## Summary
- Adds `.github/config/docs-sites.json` as the authoritative registry of all 9 Astro docs repos with `llms-full.txt` URLs
- Updates `dispatch-downstream.yml` to trigger on changes to `docs-sites.json`
- Replaces the old `gh repo list` discovery approach that caused rate limiting

## Test plan
- [ ] Verify `docs-sites.json` is valid JSON matching `starlight-llms-txt` `optionalLinks` schema
- [ ] Verify `dispatch-downstream.yml` includes `docs-sites.json` in paths trigger
- [ ] After merge, confirm dispatch fires to downstream repos

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)