### PR TITLE
feat: auto-detect and mount static asset directories in docs build

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -61,6 +61,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Detect static asset directories
+        id: assets
+        run: |
+          CONTENT="${{ inputs.content-path }}"
+          MOUNTS=""
+          for dir in "$CONTENT"/*/; do
+            [ ! -d "$dir" ] && continue
+            dirname=$(basename "$dir")
+            if ! find "$dir" -maxdepth 1 \( -name '*.md' -o -name '*.mdx' \) | grep -q .; then
+              MOUNTS="$MOUNTS -v ${{ github.workspace }}/$dir:/app/public/$dirname:ro"
+              echo "Static asset directory: $dirname"
+            fi
+          done
+          echo "mounts=$MOUNTS" >> "$GITHUB_OUTPUT"
+
       - name: Build docs with container
         run: |
           mkdir -p ${{ runner.temp }}/docs-output
@@ -68,6 +83,7 @@ jobs:
           docker run --rm \
             --name docs-builder \
             -v ${{ github.workspace }}/${{ inputs.content-path }}:/content/docs:ro \
+            ${{ steps.assets.outputs.mounts }} \
             -v ${{ runner.temp }}/docs-output:/output \
             -e CONTENT_DIR=/content/docs \
             -e OUTPUT_DIR=/output \


### PR DESCRIPTION
## Summary
- Adds a "Detect static asset directories" step before the Docker build
- Scans `content-path` subdirectories for asset-only folders (no `.md`/`.mdx` files)
- Mounts detected directories into `/app/public/<dirname>` so Astro serves them as static files

## Motivation
The Docker builder only mounts the content directory. Static assets like images and icons placed in subdirectories (e.g., `docs/images/`, `docs/brand-icons/`) end up in Astro's content collection where they're ignored, resulting in 404s on the deployed site.

## How it works
Any subdirectory under the content path that contains no Markdown files is automatically mounted as a public asset directory. This is zero-config for downstream repos — just drop assets in a subdirectory.

## Test plan
- [ ] Verify `docs/brand-icons/` SVGs are served at `/brand-icons/*.svg` after deploy
- [ ] Verify directories with `.mdx` files (e.g., `docs/guides/`) are NOT mounted as public
- [ ] Verify repos with no asset directories build normally (empty mounts string)

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)