### PR TITLE
fix: exclude release branches from linked-issue check for automated release workflows

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: nearform-actions/github-action-check-linked-issues@v1
         with:
-          exclude-branches: "dependabot/**"
+          exclude-branches: "dependabot/**,release/**"
           custom-message: >-
             This PR must be linked to a GitHub issue. Use 'Closes #123'
             in the PR description, or link an issue from the sidebar.


### PR DESCRIPTION
Closes #95