### PR TITLE
chore: onboard starlight-mega-menu into downstream governance registry

### DIFF
--- a/.github/config/downstream-repos.json
+++ b/.github/config/downstream-repos.json
@@ -10,5 +10,6 @@
   "robinmordasiewicz/f5xc-api-mcp",
   "robinmordasiewicz/f5xc-xcsh",
   "robinmordasiewicz/f5xc-docs",
-  "robinmordasiewicz/f5xc-api-enriched"
+  "robinmordasiewicz/f5xc-api-enriched",
+  "robinmordasiewicz/starlight-mega-menu"
 ]

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ Thumbs.db
 # Node
 node_modules/
 dist/
+*.tgz
 
 # Environment
 .env


### PR DESCRIPTION
Closes #101

Register starlight-mega-menu repository to the downstream governance enforcement pipeline.

## Changes
- Add starlight-mega-menu to 
- Update  to exclude  files

## Rationale
This registers starlight-mega-menu for automated governance enforcement, ensuring it receives:
- Configuration synchronization (CONTRIBUTING.md, issue/PR templates, etc.)
- Workflow enforcement (.github/workflows files)
- Security and quality standards