### PR TITLE
fix: add docs/api-reference/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,7 @@ specs/discovered/diffs/
 specs/discovered/endpoints/
 specs/discovered/schemas/
 docs/specifications/api/
+docs/api-reference/
 .version
 .etag
 .github_release


### PR DESCRIPTION
## Summary
- Add `docs/api-reference/` to `.gitignore` alongside existing `docs/specifications/api/` entry
- These MDX wrapper pages are generated by `scripts/generate_api_viewer.py` in downstream repos
- CI workflows use `git add -f` to force-commit, so this only affects local dev hygiene

## Test plan
- [ ] Verify `.gitignore` includes the new entry
- [ ] Next governance sync to downstream repos picks up the change

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)