### PR TITLE
chore: add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -66,7 +66,8 @@
       {"src": "CLAUDE.md", "dest": "CLAUDE.md"},
       {"src": ".editorconfig", "dest": ".editorconfig"},
       {"src": ".gitignore", "dest": ".gitignore"},
-      {"src": "LICENSE", "dest": "LICENSE"}
+      {"src": "LICENSE", "dest": "LICENSE"},
+      {"src": ".github/dependabot.yml", "dest": ".github/dependabot.yml"}
     ]
   }
 }

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,78 @@
+---
+version: 2
+updates:
+  # --- GitHub Actions ---
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    assignees:
+      - "robinmordasiewicz"
+    open-pull-requests-limit: 10
+    groups:
+      actions-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- npm ---
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    assignees:
+      - "robinmordasiewicz"
+    open-pull-requests-limit: 10
+    groups:
+      npm-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- pip ---
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    assignees:
+      - "robinmordasiewicz"
+    open-pull-requests-limit: 10
+    groups:
+      pip-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  # --- Docker ---
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps):"
+    labels:
+      - "dependencies"
+    assignees:
+      - "robinmordasiewicz"
+    open-pull-requests-limit: 5
+    groups:
+      docker-minor-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Add Dependabot configuration file to automate dependency updates across all 4 package ecosystems (GitHub Actions, npm, pip, Docker) and register it as a managed file for downstream governance sync.

## Changes

**New file:** 
- GitHub Actions: weekly updates, 10 PR limit
- npm: weekly updates, 10 PR limit  
- pip: weekly updates, 10 PR limit
- Docker: weekly updates, 5 PR limit
- All configured with Monday schedule and consistent labeling

**Modified:** 
- Registered dependabot.yml in managed_files array for downstream sync

## Benefits

- Automated security and dependency updates across all package ecosystems
- Consistent governance rules enforced across all downstream repositories
- Minor/patch updates grouped by ecosystem to reduce PR noise
- Monday weekly schedule to avoid update clustering
- Automatic downstream sync via existing enforcement workflow

## Implementation Details

All 4 ecosystems configured with:
- Consistent commit message prefix: `chore(deps):`
- Dependency label for issue tracking
- Assignment to @robinmordasiewicz
- Grouped updates for minor/patch versions

Closes #105