### PR TITLE
feat: dynamically generate dependabot.yml per-repo based on ecosystem detection

### DIFF
--- a/.github/config/default-repo-settings.json
+++ b/.github/config/default-repo-settings.json
@@ -66,8 +66,7 @@
       {"src": "CLAUDE.md", "dest": "CLAUDE.md"},
       {"src": ".editorconfig", "dest": ".editorconfig"},
       {"src": ".gitignore", "dest": ".gitignore"},
-      {"src": "LICENSE", "dest": "LICENSE"},
-      {"src": ".github/dependabot.yml", "dest": ".github/dependabot.yml"}
+      {"src": "LICENSE", "dest": "LICENSE"}
     ]
   }
 }

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -335,6 +335,60 @@ jobs:
                 fi
               done
 
+              # ─── Dynamic dependabot.yml generation ────────────────────────
+              echo ""
+              echo "--- Dynamic dependabot.yml ---"
+              DEPENDABOT_DRIFT=false
+
+              # Detect ecosystems in target repo
+              HAS_NPM=false; HAS_PIP=false; HAS_DOCKER=false
+              if gh api "repos/${OWNER}/${REPO}/contents/package.json" --jq '.sha' >/dev/null 2>&1; then
+                HAS_NPM=true; echo "[INFO] Detected package.json → npm"
+              fi
+              if gh api "repos/${OWNER}/${REPO}/contents/Dockerfile" --jq '.sha' >/dev/null 2>&1; then
+                HAS_DOCKER=true; echo "[INFO] Detected Dockerfile → docker"
+              fi
+              for pyfile in requirements.txt pyproject.toml setup.py; do
+                if gh api "repos/${OWNER}/${REPO}/contents/${pyfile}" --jq '.sha' >/dev/null 2>&1; then
+                  HAS_PIP=true; echo "[INFO] Detected ${pyfile} → pip"; break
+                fi
+              done
+
+              # Build dependabot.yml content
+              DEPBOT="---\nversion: 2\nupdates:\n  # --- GitHub Actions ---\n  - package-ecosystem: \"github-actions\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      actions-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+
+              if [ "$HAS_NPM" = true ]; then
+                DEPBOT="${DEPBOT}\n\n  # --- npm ---\n  - package-ecosystem: \"npm\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      npm-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              fi
+
+              if [ "$HAS_PIP" = true ]; then
+                DEPBOT="${DEPBOT}\n\n  # --- pip ---\n  - package-ecosystem: \"pip\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 10\n    groups:\n      pip-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              fi
+
+              if [ "$HAS_DOCKER" = true ]; then
+                DEPBOT="${DEPBOT}\n\n  # --- Docker ---\n  - package-ecosystem: \"docker\"\n    directory: \"/\"\n    schedule:\n      interval: \"weekly\"\n      day: \"monday\"\n    commit-message:\n      prefix: \"chore(deps):\"\n    labels:\n      - \"dependencies\"\n    assignees:\n      - \"robinmordasiewicz\"\n    open-pull-requests-limit: 5\n    groups:\n      docker-minor-patch:\n        update-types:\n          - \"minor\"\n          - \"patch\""
+              fi
+
+              DEPBOT="${DEPBOT}\n"
+              GENERATED_DEPENDABOT=$(printf '%b' "$DEPBOT")
+
+              # Compare with current dependabot.yml in target repo
+              CURRENT_DEPBOT_RESPONSE=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" 2>/dev/null) || true
+              if [ -n "$CURRENT_DEPBOT_RESPONSE" ]; then
+                CURRENT_DEPENDABOT=$(echo "$CURRENT_DEPBOT_RESPONSE" | jq -r '.content' | tr -d '\n' | base64 -d 2>/dev/null) || true
+              else
+                CURRENT_DEPENDABOT=""
+              fi
+
+              if [ "$GENERATED_DEPENDABOT" != "$CURRENT_DEPENDABOT" ]; then
+                echo "[DRIFT] .github/dependabot.yml needs update"
+                DEPENDABOT_DRIFT=true
+                DRIFT_FILES="${DRIFT_FILES}.github/dependabot.yml\n"
+                DRIFT_COUNT=$((DRIFT_COUNT + 1))
+              else
+                echo "[OK] .github/dependabot.yml"
+              fi
+
               if [ "$DRIFT_COUNT" -eq 0 ]; then
                 echo "[OK] All managed files match canonical"
               else
@@ -368,6 +422,11 @@ jobs:
 
                   # Commit each drifted file to the branch
                   for dest_file in $(printf '%b' "$DRIFT_FILES" | sed '/^$/d'); do
+                    # Skip dynamic dependabot.yml — committed separately below
+                    if [ "$dest_file" = ".github/dependabot.yml" ]; then
+                      continue
+                    fi
+
                     # Look up the source path from the manifest
                     src_file=$(echo "$MANAGED_FILES" | jq -r --arg d "$dest_file" '.files[] | select(.dest == $d) | .src')
 
@@ -395,6 +454,28 @@ jobs:
                     fi
                     echo "[OK] Synced ${dest_file}"
                   done
+
+                  # Commit dynamic dependabot.yml if drifted
+                  if [ "$DEPENDABOT_DRIFT" = true ]; then
+                    DEPBOT_B64=$(printf '%s' "$GENERATED_DEPENDABOT" | base64 -w 0)
+                    DEPBOT_SHA=$(gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --jq '.sha' 2>/dev/null) || true
+
+                    if [ -n "$DEPBOT_SHA" ]; then
+                      jq -n --arg msg "chore: update .github/dependabot.yml" \
+                            --arg content "$DEPBOT_B64" \
+                            --arg sha "$DEPBOT_SHA" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"sha":$sha,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
+                    else
+                      jq -n --arg msg "chore: create .github/dependabot.yml" \
+                            --arg content "$DEPBOT_B64" \
+                            --arg branch "governance/sync-managed-files" \
+                        '{"message":$msg,"content":$content,"branch":$branch}' | \
+                        gh api "repos/${OWNER}/${REPO}/contents/.github/dependabot.yml" --method PUT --input - >/dev/null
+                    fi
+                    echo "[OK] Synced .github/dependabot.yml (dynamic)"
+                  fi
 
                   # Create PR
                   PR_BODY=$(printf 'Closes #%s\n\nSynced managed files from `%s` canonical source:\n\n%s' \


### PR DESCRIPTION
Closes #111

## Summary

- Remove `.github/dependabot.yml` from the static `managed_files` list in `default-repo-settings.json`
- Add dynamic dependabot.yml generation in Phase 7 of `enforce-repo-settings.yml`
- The workflow detects ecosystems per downstream repo:
  - `github-actions` — always included (every repo has workflows)
  - `npm` — included when `package.json` exists
  - `pip` — included when `requirements.txt`, `pyproject.toml`, or `setup.py` exists
  - `docker` — included when `Dockerfile` exists

## How it works

After the static managed file drift detection loop, the workflow:
1. Probes the GitHub API for ecosystem indicator files in the target repo
2. Generates the appropriate `dependabot.yml` YAML content
3. Compares with the current `.github/dependabot.yml` in the target repo
4. If drifted, includes it in the governance sync PR alongside any other managed file changes

## Test plan

- [ ] Merge and trigger dispatch to a repo with only `package.json` (e.g., starlight-mega-menu) — should get `github-actions` + `npm` only
- [ ] Verify a repo with `Dockerfile` gets `docker` ecosystem added
- [ ] Verify a repo with no Python/Docker files does NOT get `pip`/`docker` sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)