### PR TITLE
fix: trim dependabot.yml to github-actions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,8 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
     commit-message:
       prefix: "chore(deps):"
     labels:
@@ -15,60 +16,6 @@ updates:
     open-pull-requests-limit: 10
     groups:
       actions-minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
-  # --- npm ---
-  - package-ecosystem: "npm"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore(deps):"
-    labels:
-      - "dependencies"
-    assignees:
-      - "robinmordasiewicz"
-    open-pull-requests-limit: 10
-    groups:
-      npm-minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
-  # --- pip ---
-  - package-ecosystem: "pip"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore(deps):"
-    labels:
-      - "dependencies"
-    assignees:
-      - "robinmordasiewicz"
-    open-pull-requests-limit: 10
-    groups:
-      pip-minor-patch:
-        update-types:
-          - "minor"
-          - "patch"
-
-  # --- Docker ---
-  - package-ecosystem: "docker"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    commit-message:
-      prefix: "chore(deps):"
-    labels:
-      - "dependencies"
-    assignees:
-      - "robinmordasiewicz"
-    open-pull-requests-limit: 5
-    groups:
-      docker-minor-patch:
         update-types:
           - "minor"
           - "patch"


### PR DESCRIPTION
Closes #113

## Summary

- Remove `npm`, `pip`, and `docker` ecosystems from the template repo's own `dependabot.yml` — no `package.json`, `Dockerfile`, or Python files exist
- Switch from daily to weekly/monday schedule to reduce PR noise

Note: This only affects the template repo itself. Downstream repos now get dynamically generated `dependabot.yml` via the smart sync in PR #112.

## Test plan

- [ ] Verify no more failing Dependabot runs for pip/docker/npm on f5xc-template

🤖 Generated with [Claude Code](https://claude.com/claude-code)