### PR TITLE
Add CI monitoring and problem reporting rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,26 +32,27 @@ Use the format `<prefix>/<issue-number>-short-description`:
 
 ## CI Monitoring and Problem Reporting
 
-When monitoring GitHub Actions workflows,
-**never ignore or dismiss failures** — even if they
-are pre-existing or unrelated to your current change.
+When monitoring CI workflows, **never ignore
+failures** — even pre-existing or unrelated ones.
+You are authorized to create GitHub issues without
+asking for confirmation. This is a standing
+instruction, not a suggestion.
 
-For every problem observed during CI monitoring:
+For every problem observed:
 
-1. **Create a GitHub issue** in the affected repo
+1. **Immediately create a GitHub issue** — do not
+   ask whether to create it, just create it
    - Use a clear, descriptive title
    - Include the workflow run URL or relevant logs
    - Note it was discovered during CI monitoring
-     of a different change
    - Apply the `bug` label
-2. **Continue with your primary task** — do not let
-   issue creation block your current work
-3. **Report to the user** — mention the issues you
-   created so they have visibility
+2. **Continue with your primary task** — issue
+   creation must not block your current work
+3. **Report to the user** what issues you created
 
-Never say "pre-existing issue, unrelated to our
-change" and move on. If you see a problem,
-document it.
+Do not ask "Want me to create an issue?" — the
+answer is always yes. See a problem, file an issue,
+move on.
 
 ## Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,29 @@ Use the format `<prefix>/<issue-number>-short-description`:
 - Fill out the PR template completely
 - Follow conventional commit messages (`feat:`, `fix:`, `docs:`)
 
+## CI Monitoring and Problem Reporting
+
+When monitoring GitHub Actions workflows,
+**never ignore or dismiss failures** — even if they
+are pre-existing or unrelated to your current change.
+
+For every problem observed during CI monitoring:
+
+1. **Create a GitHub issue** in the affected repo
+   - Use a clear, descriptive title
+   - Include the workflow run URL or relevant logs
+   - Note it was discovered during CI monitoring
+     of a different change
+   - Apply the `bug` label
+2. **Continue with your primary task** — do not let
+   issue creation block your current work
+3. **Report to the user** — mention the issues you
+   created so they have visibility
+
+Never say "pre-existing issue, unrelated to our
+change" and move on. If you see a problem,
+document it.
+
 ## Reference
 
 Read `CONTRIBUTING.md` for full governance details.


### PR DESCRIPTION
## Summary

- Adds a "CI Monitoring and Problem Reporting" section to `CLAUDE.md`
- Instructs Claude Code to never dismiss pre-existing CI failures — instead, create a GitHub issue for every problem observed during workflow monitoring
- Ensures problems are documented as backlog items rather than silently ignored

Closes #115

## Test plan

- [x] New section is present in `CLAUDE.md` after "Rules" section
- [x] Markdownlint passes on the new content (only pre-existing line-length violations remain)
- [x] Instructions are clear and unambiguous

🤖 Generated with [Claude Code](https://claude.com/claude-code)