### PR TITLE
chore: add out/ and .auto-claude/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,9 +66,11 @@ projects/
 # Tool-specific
 .playwright-mcp/
 .serena/
+.auto-claude/
 claudedocs/
 cache/
 src/generated/
+out/
 
 # API spec pipeline
 specs/original/


### PR DESCRIPTION
## Summary
- Add `out/` (VS Code extension build output) to `.gitignore`
- Add `.auto-claude/` (Claude Code auto-generated session directory) to `.gitignore`

## Test plan
- [ ] Verify both entries appear in `.gitignore` under `# Tool-specific`
- [ ] Confirm template sync propagates to downstream repos

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)