### PR TITLE
feat: add universal .pre-commit-config.yaml for governance enforcement

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,9 @@
+self-hosted-runner:
+  labels: []
+
+config-variables: null
+
+paths:
+  .github/workflows/**/*.yml:
+    ignore:
+      - "SC2016:.+"

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,9 @@
+{
+  "MD013": false,
+  "MD022": false,
+  "MD029": false,
+  "MD032": false,
+  "MD040": false,
+  "MD041": false,
+  "MD060": false
+}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,58 @@
+---
+repos:
+  - repo: local
+    hooks:
+      - id: local-hooks
+        name: Repository-specific hooks
+        entry: bash -c 'if [ -x scripts/pre-commit-local.sh ]; then scripts/pre-commit-local.sh; fi'
+        language: system
+        always_run: true
+        pass_filenames: false
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v6.0.0
+    hooks:
+      - id: no-commit-to-branch
+        args: ["--branch", "main"]
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+        args: ["--fix=lf"]
+      - id: check-yaml
+        args: ["--allow-multiple-documents"]
+      - id: check-json
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+
+  - repo: https://github.com/igorshubovych/markdownlint-cli
+    rev: v0.47.0
+    hooks:
+      - id: markdownlint
+        args: ["--fix"]
+
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1
+    hooks:
+      - id: shellcheck
+
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.10
+    hooks:
+      - id: actionlint
+
+ci:
+  autofix_prs: true
+  autoupdate_schedule: weekly
+  skip: [local-hooks, gitleaks]

--- a/.yamllint.yaml
+++ b/.yamllint.yaml
@@ -1,0 +1,10 @@
+---
+extends: default
+
+rules:
+  document-start: disable
+  line-length: disable
+  truthy:
+    allowed-values: ["true", "false", "on"]
+  comments:
+    min-spaces-from-content: 1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,13 @@ workflows succeed, and local branches are cleaned.
 6. **Wait for auto-merge** — PRs merge automatically
    (squash) once all CI checks pass. Poll until the
    PR state is `MERGED`:
+
    ```
    gh pr view <NUMBER> --json state --jq '.state'
    ```
+
    If the PR is not merging, check for issues:
+
    ```
    gh pr view <NUMBER> --json mergeable,mergeStateStatus
    ```
@@ -40,6 +43,7 @@ workflows succeed, and local branches are cleaned.
    `main` triggers additional workflows (docs
    builds, governance sync, etc.). Discover and
    watch them:
+
    ```
    git checkout main && git pull origin main
    MERGE_SHA=$(git rev-parse HEAD)
@@ -64,12 +68,14 @@ workflows succeed, and local branches are cleaned.
 9. **Clean up branches** — only after all workflows
     succeed. Delete your feature branch and any other
     stale local branches already merged to `main`:
+
     ```
     git branch -d <branch-name>
     git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
     ```
 
 10. **Verify completion** — confirm clean state:
+
     ```
     git status
     git branch
@@ -155,6 +161,7 @@ files, or other workspace issues:
    responsibility
 
 Stale branch cleanup command:
+
 ```
 git branch --merged main | grep -v '^\*\|main' | xargs -r git branch -d
 ```


### PR DESCRIPTION
## Summary

- Add universal `.pre-commit-config.yaml` with hooks common across 5+ downstream repos
- Include local-hooks escape hatch (`scripts/pre-commit-local.sh`) for repo-specific hooks
- Add tool configs (`.yamllint.yaml`, `.markdownlint.json`, `.github/actionlint.yaml`) for this repo
- Configure `ci:` section for pre-commit.ci (autofix PRs, weekly updates, skip local-hooks/gitleaks)

## Hooks included

| Hook | Version | Purpose |
|------|---------|---------|
| pre-commit-hooks | v6.0.0 | no-commit-to-branch, trailing-whitespace, end-of-file-fixer, mixed-line-ending, check-yaml, check-json, check-added-large-files, check-merge-conflict, detect-private-key |
| gitleaks | v8.30.0 | Secret detection |
| yamllint | v1.38.0 | YAML linting |
| markdownlint-cli | v0.47.0 | Markdown linting with --fix |
| shellcheck-py | v0.11.0.1 | Shell script linting |
| actionlint | v1.7.10 | GitHub Actions validation |

## Related Issue

Closes #127

## Test plan

- [x] `pre-commit run --all-files` passes in f5xc-template
- [ ] CI checks pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)