### PR TITLE
docs: add DOCS_TITLE extraction and static asset mount guidance to Local Preview

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,12 +242,23 @@ docker run --rm -it \
     cp /app/node_modules/f5xc-docs-theme/src/content.config.ts \
        /app/src/content.config.ts && \
     cp -r /content/docs/* /app/src/content/docs/ && \
+    DOCS_TITLE=$(grep -m1 "^title:" /app/src/content/docs/index.mdx \
+      | sed "s/title: *[\"]*//;s/[\"]*$//") \
     npx astro dev --host
   '
 ```
 
 Open `http://localhost:4321`. File changes on the
 host require restarting the container.
+
+If your `docs/` directory contains static asset
+subdirectories (images, diagrams — folders with
+no `.md`/`.mdx` files), add a volume mount for
+each one so they are served as public assets:
+
+```bash
+-v "$(pwd)/docs/images:/app/public/images:ro"
+```
 
 For a full production build:
 


### PR DESCRIPTION
## Summary
- Add `DOCS_TITLE` extraction from `index.mdx` frontmatter to the dev server command in Local Preview
- Add guidance for mounting static asset directories (images, diagrams) as public assets

Closes #132

## Test plan
- [ ] Verify the updated dev server command extracts DOCS_TITLE from index.mdx frontmatter
- [ ] Verify static asset mount example is clear and uses the `:ro` flag
- [ ] Confirm CLAUDE.md syncs correctly to consuming repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)