### PR TITLE
fix: add concurrency settings to dispatch-downstream workflow

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -24,6 +24,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: dispatch-downstream
+  cancel-in-progress: true
+
 jobs:
   dispatch:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add `concurrency` group with `cancel-in-progress: true` to `dispatch-downstream.yml`
- Prevents duplicate downstream dispatches when multiple pushes to `main` land in quick succession

Closes #137

## Test plan
- [ ] CI passes
- [ ] Next time multiple governance files merge back-to-back, only one dispatch runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)