### PR TITLE
feat: add concurrency settings to managed workflows

### DIFF
--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -8,6 +8,10 @@ permissions:
   issues: read
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   check-linked-issue:
     runs-on: ubuntu-latest

--- a/workflows/auto-merge.yml
+++ b/workflows/auto-merge.yml
@@ -8,6 +8,10 @@ permissions:
   contents: write
   pull-requests: write
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   auto-merge:
     uses: robinmordasiewicz/f5xc-template/.github/workflows/auto-merge.yml@main

--- a/workflows/enforce-repo-settings.yml
+++ b/workflows/enforce-repo-settings.yml
@@ -12,6 +12,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: enforce-repo-settings
+  cancel-in-progress: true
+
 jobs:
   enforce:
     uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings.yml@main


### PR DESCRIPTION
## Summary

- Add `concurrency` block to `workflows/enforce-repo-settings.yml` (static group)
- Add `concurrency` block to `workflows/auto-merge.yml` (branch-scoped)
- Add `concurrency` block to `.github/workflows/require-linked-issue.yml` (PR-number scoped, since it uses `pull_request_target`)

These are managed files that auto-sync to all 13 downstream repos via the enforcement workflow.

## Test plan

- [ ] `actionlint` passes on all modified workflows
- [ ] PR CI checks pass
- [ ] After merge, dispatch-downstream triggers and sync PRs appear in downstream repos
- [ ] Downstream repos' auto-merge and enforce-repo-settings workflows show concurrency in run metadata

Closes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)